### PR TITLE
使用する定数値を変更

### DIFF
--- a/resultoon.py
+++ b/resultoon.py
@@ -10,7 +10,7 @@ import requests
 import config
 
 
-rightup_template = cv2.imread("./templates/result_upright_binary.bmp", cv2.CV_LOAD_IMAGE_GRAYSCALE)
+rightup_template = cv2.imread("./templates/result_upright_binary.bmp", cv2.IMREAD_GRAYSCALE)
 
 numbers = []
 for x in xrange(10):
@@ -28,8 +28,8 @@ stage_tpls = [cv2.imread('./templates/stages/' + name + '.png', cv2.IMREAD_GRAYS
               for name in stage_names]
 
 cap = cv2.VideoCapture(config.CAPTURE_BOARD_DEVICE_ID)
-cap.set(cv2.cv.CV_CAP_PROP_FRAME_WIDTH, 1280)
-cap.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 720)
+cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
 
 display_info = {}  # 画面に表示したい情報
 
@@ -217,7 +217,7 @@ def draw_info_on_display(frame):
     y = 1
     for item in display_info.items():
         cv2.putText(frame, item[0] + ": " + item[1], (10, y*50),
-                    cv2.FONT_HERSHEY_SIMPLEX, 2, 255, 2, cv2.CV_AA)
+                    cv2.FONT_HERSHEY_SIMPLEX, 2, 255, 2, cv2.LINE_AA)
         y += 1
     return frame
 


### PR DESCRIPTION
Mac上で同様のライブラリを使用してResultoonを試していたところ、定数がないというエラーで起動しなかったので報告までPRします。
- homebrew/science/opencv3: stable 3.0.0 (bottled)
- Python 2.7.5

```
$ pip freeze
appnope==0.1.0
decorator==4.0.2
gnureadline==6.3.3
ipython==4.0.0
ipython-genutils==0.1.0
numpy==1.9.2
path.py==8.1.1
pexpect==3.3
pickleshare==0.5
pytesseract==0.1.6
requests==2.7.0
simplegeneric==0.8.1
tesseract==0.1.3
traitlets==4.0.0
```
